### PR TITLE
Update probot npm package due to change by probot

### DIFF
--- a/action.js
+++ b/action.js
@@ -1,5 +1,5 @@
 // Require the adapter
-const adapt = require('probot-actions-adapter');
+const adapt = require('adapter-github-actions');
 
 // Require your Probot app's entrypoint, usually this is just index.js
 const probot = require('./index');

--- a/dist/index.js
+++ b/dist/index.js
@@ -61,7 +61,7 @@ module.exports = robot => {
 /***/ 407:
 /***/ ((module) => {
 
-module.exports = eval("require")("probot-actions-adapter");
+module.exports = eval("require")("adapter-github-actions");
 
 
 /***/ })

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@actions/core": "1.2.6",
     "@actions/github": "2.1.1",
-    "probot-actions-adapter": "1.0.2"
+    "@probot/adapter-github-actions": "3.0.1"
   },
   "devDependencies": {
     "@zeit/ncc": "0.21.1"


### PR DESCRIPTION
Dependency has been deprecated https://www.npmjs.com/package/probot-actions-adapter
> Renamed to @probot/adapter-github-actions. See https://github.com/probot/adapter-github-actions/releases/tag/v3.0.0
